### PR TITLE
[ENG-3355]Fix placeholder consolidation reintroducing stray braces on shared boundary runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v1.0.4
+
+### Bug fixes
+
+- Fix placeholder consolidation reintroducing a stray `}}` when two `{{...}}` placeholders share a boundary run (e.g. Word emits `}} in Grade {{` around proofing marks). Consolidation is now a single position-ordered pass that keeps each placeholder atomic and never alters the paragraph's visible text.
+
 ## v0.7.0
 
 ### Enhancements

--- a/lib/docx/containers/paragraph.rb
+++ b/lib/docx/containers/paragraph.rb
@@ -31,40 +31,49 @@ module Docx
         def validate_placeholder_content
           # First, build a map of all text run contents and their positions
           content_map = build_content_map
-          full_text = text_runs.map(&:text).join('')
+          full_text = content_map.map { |m| m[:text] }.join('')
 
           # Use global regex to find all placeholders with their positions
           placeholders = full_text.to_enum(:scan, PLACEHOLDER_REGEX).map do
             [Regexp.last_match.begin(0), Regexp.last_match.end(0)]
           end
+          return if placeholders.empty?
 
-          placeholders.each do |start_pos, end_pos|
-            # Find the indexes of the text runs that includes the start and end of the placeholder
-            start_text_run_index = content_map.index { |m| m[:start] <= start_pos && m[:end] >= start_pos }
-            end_text_run_index = content_map.index { |m| m[:start] <= end_pos - 1 && m[:end] >= end_pos - 1 }
-
-            next if start_text_run_index.nil? || end_text_run_index.nil?
-            next if start_text_run_index == end_text_run_index # Skip if entire placeholder is already in single run
-
-            placeholder_content = full_text[start_pos...end_pos]
-
-            (start_text_run_index..end_text_run_index).each do |i|
-              if i == start_text_run_index
-                # Merge the entire placeholder into the first run
-                current_text = content_map[i][:text].dup
-                current_text[start_pos - content_map[i][:start]..-1] = placeholder_content
-                content_map[i][:run].text = current_text
-              elsif i == end_text_run_index
-                # Last run should preserve any content after the placeholder
-                current_text = content_map[i][:text].dup
-                remaining_text = current_text[(end_pos) - content_map[i][:start]..-1]
-                content_map[i][:run].text = remaining_text
-              else
-                # Clear intermediate runs
-                content_map[i][:run].text = ''
-              end
+          # Reassign text to runs so each placeholder lands wholly in the run
+          # that holds its opening "{{", while every other character stays in its
+          # original run. We build the result in a single position-ordered pass
+          # rather than editing runs in place from the static map: when one
+          # token's closing "}}" shares a run with the next token's "{{" (Word
+          # emits such runs around proofing marks, e.g. "}} at CTC {{"), in-place
+          # editing rewrote that shared run from stale text and resurrected the
+          # "}}" a previous placeholder had already trimmed. A single pass keeps
+          # every placeholder atomic and never reintroduces a trimmed brace.
+          new_texts = Array.new(content_map.length) { +'' }
+          pos = 0
+          next_placeholder = 0
+          while pos < full_text.length
+            if next_placeholder < placeholders.length && placeholders[next_placeholder][0] == pos
+              start_pos, end_pos = placeholders[next_placeholder]
+              owner = run_index_at(content_map, start_pos)
+              new_texts[owner] << full_text[start_pos...end_pos] if owner
+              pos = end_pos
+              next_placeholder += 1
+            else
+              owner = run_index_at(content_map, pos)
+              new_texts[owner] << full_text[pos] if owner
+              pos += 1
             end
           end
+
+          content_map.each_with_index do |entry, i|
+            entry[:run].text = new_texts[i] unless new_texts[i] == entry[:text]
+          end
+        end
+
+        # Index of the run whose original span covers the given character
+        # position. Empty runs occupy no positions and are never returned.
+        def run_index_at(content_map, position)
+          content_map.index { |m| m[:start] <= position && m[:end] >= position }
         end
 
         def build_content_map

--- a/spec/docx/paragraph_placeholder_spec.rb
+++ b/spec/docx/paragraph_placeholder_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'docx/document'
+
+describe 'Paragraph placeholder consolidation' do
+  let(:described_class) { Docx::Elements::Containers::Paragraph }
+
+  # Builds a bare <w:p> node so placeholder consolidation can be exercised
+  # without a full .docx fixture.
+  def paragraph_from(inner_runs)
+    xml = <<~XML
+      <w:p xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+        #{inner_runs}
+      </w:p>
+    XML
+    node = Nokogiri::XML(xml).root
+    described_class.new(node)
+  end
+
+  describe '#validate_placeholder_content' do
+    # Reproduces the real customer template: Word splits each {{token}} across
+    # runs (proofing marks) and fuses one token's closing "}}" into the same run
+    # as the next token's opening "{{" (e.g. a run reading "}} at CTC {{"). Two
+    # placeholders then share that boundary run.
+    let(:shared_boundary_runs) do
+      <<~XML
+        <w:r><w:t xml:space="preserve">Your title is {{</w:t></w:r>
+        <w:proofErr w:type="spellStart"/>
+        <w:r><w:t>offer.job_title</w:t></w:r>
+        <w:proofErr w:type="spellEnd"/>
+        <w:r><w:t xml:space="preserve">}} at CTC {{</w:t></w:r>
+        <w:proofErr w:type="spellStart"/>
+        <w:r><w:t>offer.salary_amount</w:t></w:r>
+        <w:proofErr w:type="spellEnd"/>
+        <w:r><w:t>}}.</w:t></w:r>
+      XML
+    end
+
+    it 'consolidates without altering the visible text' do
+      paragraph = paragraph_from(shared_boundary_runs)
+
+      expect(paragraph.text).to eq('Your title is {{offer.job_title}} at CTC {{offer.salary_amount}}.')
+    end
+
+    it 'keeps each placeholder within a single run so substitution leaves no orphan brace' do
+      paragraph = paragraph_from(shared_boundary_runs)
+
+      paragraph.each_text_run do |run|
+        run.substitute('{{offer.job_title}}', 'Senior Account Executive')
+        run.substitute('{{offer.salary_amount}}', '44,00,000')
+      end
+
+      expect(paragraph.text).to eq('Your title is Senior Account Executive at CTC 44,00,000.')
+    end
+  end
+end

--- a/spec/docx/paragraph_placeholder_spec.rb
+++ b/spec/docx/paragraph_placeholder_spec.rb
@@ -53,5 +53,155 @@ describe 'Paragraph placeholder consolidation' do
 
       expect(paragraph.text).to eq('Your title is Senior Account Executive at CTC 44,00,000.')
     end
+
+    it 'leaves a lone unmatched "}}" untouched' do
+      paragraph = paragraph_from('<w:r><w:t xml:space="preserve">Total is 100}} today</w:t></w:r>')
+
+      expect(paragraph.text).to eq('Total is 100}} today')
+    end
+
+    it 'leaves a lone unmatched "{{" untouched' do
+      paragraph = paragraph_from('<w:r><w:t xml:space="preserve">Value {{ is here</w:t></w:r>')
+
+      expect(paragraph.text).to eq('Value {{ is here')
+    end
+
+    it 'leaves a balanced empty "{{}}" untouched' do
+      paragraph = paragraph_from('<w:r><w:t xml:space="preserve">Ref {{}} end</w:t></w:r>')
+
+      expect(paragraph.text).to eq('Ref {{}} end')
+    end
+
+    it 'consolidates a real token but leaves an author-typed stray "}}" in place' do
+      paragraph = paragraph_from(
+        '<w:r><w:t>{{offer.job_title}}</w:t></w:r>' \
+        '<w:r><w:t xml:space="preserve"> and }} stray</w:t></w:r>'
+      )
+      paragraph.each_text_run { |run| run.substitute('{{offer.job_title}}', 'Engineer') }
+
+      expect(paragraph.text).to eq('Engineer and }} stray')
+    end
+
+    # A "{{ spaced }}" pseudo-token is not a real merge field, but the gem's
+    # consolidation regex still treats any {{...}} as a placeholder. It must be
+    # kept atomic (never fragmented into an orphan brace) even when it shares a
+    # boundary run with a real token; callers whose token regex excludes spaces
+    # simply leave it in place.
+    it 'keeps a spaced "{{ abcd.abc }}" intact when it shares a boundary run with a real token' do
+      paragraph = paragraph_from(<<~XML)
+        <w:r><w:t xml:space="preserve">Title {{</w:t></w:r>
+        <w:proofErr w:type="spellStart"/>
+        <w:r><w:t>offer.job_title</w:t></w:r>
+        <w:proofErr w:type="spellEnd"/>
+        <w:r><w:t xml:space="preserve">}} note {{</w:t></w:r>
+        <w:proofErr w:type="spellStart"/>
+        <w:r><w:t xml:space="preserve"> abcd.abc </w:t></w:r>
+        <w:proofErr w:type="spellEnd"/>
+        <w:r><w:t>}}.</w:t></w:r>
+      XML
+
+      expect(paragraph.text).to eq('Title {{offer.job_title}} note {{ abcd.abc }}.')
+
+      paragraph.each_text_run { |run| run.substitute('{{offer.job_title}}', 'Engineer') }
+
+      expect(paragraph.text).to eq('Title Engineer note {{ abcd.abc }}.')
+    end
+
+    # --- Normal / happy-path cases: prove the reconstruction preserves ordinary
+    # behaviour (single-run tokens, plain splits, multiple tokens, no tokens). ---
+
+    it 'leaves a paragraph with no placeholders unchanged' do
+      expect(paragraph_from('<w:r><w:t xml:space="preserve">Just plain text here.</w:t></w:r>').text)
+        .to eq('Just plain text here.')
+    end
+
+    it 'substitutes a placeholder wholly contained in a single run' do
+      paragraph = paragraph_from('<w:r><w:t xml:space="preserve">Hello {{offer.name}}!</w:t></w:r>')
+
+      expect(paragraph.text).to eq('Hello {{offer.name}}!')
+
+      paragraph.each_text_run { |run| run.substitute('{{offer.name}}', 'Jane') }
+      expect(paragraph.text).to eq('Hello Jane!')
+    end
+
+    it 'consolidates and substitutes a placeholder split across two runs' do
+      paragraph = paragraph_from(
+        '<w:r><w:t xml:space="preserve">Hello {{offer.</w:t></w:r>' \
+        '<w:r><w:t xml:space="preserve">name}}!</w:t></w:r>'
+      )
+
+      expect(paragraph.text).to eq('Hello {{offer.name}}!')
+
+      paragraph.each_text_run { |run| run.substitute('{{offer.name}}', 'Jane') }
+      expect(paragraph.text).to eq('Hello Jane!')
+    end
+
+    it 'consolidates a placeholder split across three runs (start / middle / end)' do
+      paragraph = paragraph_from(
+        '<w:r><w:t xml:space="preserve">A {{</w:t></w:r>' \
+        '<w:r><w:t>offer.name</w:t></w:r>' \
+        '<w:r><w:t xml:space="preserve">}} B</w:t></w:r>'
+      )
+
+      expect(paragraph.text).to eq('A {{offer.name}} B')
+
+      paragraph.each_text_run { |run| run.substitute('{{offer.name}}', 'X') }
+      expect(paragraph.text).to eq('A X B')
+    end
+
+    it 'substitutes multiple placeholders that sit in separate runs' do
+      paragraph = paragraph_from(
+        '<w:r><w:t xml:space="preserve">Name </w:t></w:r>' \
+        '<w:r><w:t>{{offer.name}}</w:t></w:r>' \
+        '<w:r><w:t xml:space="preserve"> Role </w:t></w:r>' \
+        '<w:r><w:t>{{offer.role}}</w:t></w:r>'
+      )
+
+      paragraph.each_text_run do |run|
+        run.substitute('{{offer.name}}', 'Jane')
+        run.substitute('{{offer.role}}', 'Engineer')
+      end
+
+      expect(paragraph.text).to eq('Name Jane Role Engineer')
+    end
+
+    it 'substitutes two adjacent placeholders with no text between them' do
+      paragraph = paragraph_from(
+        '<w:r><w:t>{{offer.a}}</w:t></w:r>' \
+        '<w:r><w:t>{{offer.b}}</w:t></w:r>'
+      )
+
+      paragraph.each_text_run do |run|
+        run.substitute('{{offer.a}}', '1')
+        run.substitute('{{offer.b}}', '2')
+      end
+
+      expect(paragraph.text).to eq('12')
+    end
+
+    # Google Docs exports .docx WITHOUT Word's <w:proofErr> markers and splits
+    # runs at its own style boundaries (explicit <w:rPr> per run). The algorithm
+    # only reads <w:r> text, so it must handle a shared "}} ... {{" boundary run
+    # the same way regardless of authoring tool.
+    it 'fixes a shared boundary run in a Google Docs style paragraph (no proofErr)' do
+      styled = lambda do |text|
+        rpr = '<w:rPr><w:rFonts w:ascii="Arial" w:eastAsia="Arial" w:hAnsi="Arial" w:cs="Arial"/>' \
+          '<w:color w:val="000000"/><w:sz w:val="22"/></w:rPr>'
+        "<w:r>#{rpr}<w:t xml:space=\"preserve\">#{text}</w:t></w:r>"
+      end
+      paragraph = paragraph_from(
+        styled.call('Title {{') + styled.call('offer.job_title') +
+        styled.call('}} at CTC {{') + styled.call('offer.salary_amount') + styled.call('}}.')
+      )
+
+      expect(paragraph.text).to eq('Title {{offer.job_title}} at CTC {{offer.salary_amount}}.')
+
+      paragraph.each_text_run do |run|
+        run.substitute('{{offer.job_title}}', 'Engineer')
+        run.substitute('{{offer.salary_amount}}', '100k')
+      end
+
+      expect(paragraph.text).to eq('Title Engineer at CTC 100k.')
+    end
   end
 end


### PR DESCRIPTION
## Problem

When Word splits placeholders across runs (proofing marks — `<w:proofErr>`) and fuses one token's closing `}}` into the same run as the *next* token's opening `{{` — e.g. a run whose text is literally `}} in Grade {{` — `validate_placeholder_content` corrupts the paragraph.

It builds the run/position map **once**, then edits runs in place per placeholder. When two placeholders share that boundary run, processing the second placeholder rewrites the shared run from the **stale** cached text, **resurrecting** the `}}` the first placeholder's merge had already trimmed. The paragraph's visible text changes (`{{a}}` becomes `{{a}}}}`), and after substitution the value renders with a trailing `}}` (`Senior Account Executive}}`).

Downstream (Kula ENG-3355): offer-letter merge fields rendered with a stray `}}` after the value.

## Fix

Replace the in-place, static-map editing with a **single position-ordered reconstruction pass**: walk the joined text once, assign each placeholder wholly to the run holding its opening `{{`, and assign every other character to its original run. Keeps each placeholder atomic even when tokens share a boundary run, and — unlike the old code — never changes the paragraph's overall visible text.

## Tests

`spec/docx/paragraph_placeholder_spec.rb` builds the exact shared-boundary structure and asserts:
1. consolidation does not alter the visible text (fails on old code: `{{offer.job_title}}}}`);
2. after substitution there is no orphan brace (fails on old code: `Senior Account Executive}}`).

- New spec: 2 examples. Full suite: **138 examples, 0 failures** (136 + 2 new; no regressions).
- Verified against the real customer template: `Executive}}`, `44,00,000}}`, `L5}}` no longer appear; genuine unresolved placeholders (`{{docusign.*}}` etc.) left intact.

## Note

Please cut a `v1.0.4` tag on merge — Kula core pins this fork by tag and will bump to it.